### PR TITLE
Update compatibility.md

### DIFF
--- a/docs/_pages/compatibility.md
+++ b/docs/_pages/compatibility.md
@@ -70,6 +70,7 @@ Sandboxing challenges are [covered in the dedicated section](sandbox).
 | `bit32` library | ✔️ | |
 | `string.gsub` is stricter about using `%` on special characters only | ✔️ | |
 | light C functions | 😞 | this changes semantics of fenv on C functions and has complex implications wrt runtime performance |
+| tables honor the `__newindex` metamethod for `nil` and `NaN` | 🤷‍♀️ | no strong use cases and more complicated semantics, compatibility and performance implications |
 
 Two things that are important to call out here are various new metamethods for tables and yielding in metamethods. In both cases, there are performance implications to supporting this - our implementation is *very* highly tuned for performance, so any changes that affect the core fundamentals of how Lua works have a price. To support yielding in metamethods we'd need to make the core of the VM more involved, since almost every single "interesting" opcode would need to learn how to be resumable - which also complicates future JIT/AOT story. Metamethods in general are important for extensibility, but very challenging to deal with in implementation, so we err on the side of not supporting any new metamethods unless a strong need arises.
 


### PR DESCRIPTION
I can only find anything mentioning this feature [here](http://lua-users.org/lists/lua-l/2012-04/msg00219.html). In Lua 5.1, `__newindex` metamethod is only invoked for `nil` and `NaN` on userdatas; but in Lua 5.2, this has changed that `__newindex` invokes for `nil` and `NaN` on tables as well.

I guess this has compatibility implications and is changing the semantics but I put the status as ' 🤷‍♀️ ' as I'm not sure what zeux's position on this is.

I made a pull request to document this as given that Lua 5.2 has changed a lot with metatables (`__len` on tables, `__pairs` and `__ipairs`, `__lt` and `__le` on different types, and now this), this might as well be intentional.